### PR TITLE
Add silent sound when device is in silent mode

### DIFF
--- a/lib/mobile_app_notifications.dart
+++ b/lib/mobile_app_notifications.dart
@@ -67,17 +67,19 @@ void ringAlarm(int id, Map<String, dynamic> data) async {
 
     print(" ----- ------- -- - - - --- -channelId: $channelId");
     final AndroidNotificationDetails androidPlatformChannelSpecifics = AndroidNotificationDetails(
-      mute? 'Silent $channelId' : channelId,
-      mute? 'Silent $channelName' : channelName,
+      mute ? 'Silent $channelId' : channelId,
+      mute ? 'Silent $channelName' : channelName,
       channelDescription: isPreNotification ? 'Pre Adhan notifications for $prayer' : 'Adhan notifications for $prayer',
       importance: Importance.max,
       priority: Priority.high,
       playSound: !isPreNotification || !mute,
-      sound: isPreNotification || (mute)
-          ? null
-          : soundType == SoundType.customSound
-              ? RawResourceAndroidNotificationSound(adhanSound)
-              : UriAndroidNotificationSound(adhanSound ?? ''),
+      sound: (mute)
+          ? const RawResourceAndroidNotificationSound('silent_sound')
+          : isPreNotification
+              ? null
+              : soundType == SoundType.customSound
+                  ? RawResourceAndroidNotificationSound(adhanSound)
+                  : UriAndroidNotificationSound(adhanSound ?? ''),
       enableVibration: true,
       largeIcon: const DrawableResourceAndroidBitmap('logo'),
       icon: 'logo',

--- a/lib/mobile_app_notifications.dart
+++ b/lib/mobile_app_notifications.dart
@@ -67,8 +67,8 @@ void ringAlarm(int id, Map<String, dynamic> data) async {
 
     print(" ----- ------- -- - - - --- -channelId: $channelId");
     final AndroidNotificationDetails androidPlatformChannelSpecifics = AndroidNotificationDetails(
-      mute ? 'Silent $channelId' : channelId,
-      mute ? 'Silent $channelName' : channelName,
+      mute ? 'Silent' : channelId,
+      mute ? 'Silent' : channelName,
       channelDescription: isPreNotification ? 'Pre Adhan notifications for $prayer' : 'Adhan notifications for $prayer',
       importance: Importance.max,
       priority: Priority.high,

--- a/lib/mobile_app_notifications.dart
+++ b/lib/mobile_app_notifications.dart
@@ -67,7 +67,7 @@ void ringAlarm(int id, Map<String, dynamic> data) async {
 
     print(" ----- ------- -- - - - --- -channelId: $channelId");
     final AndroidNotificationDetails androidPlatformChannelSpecifics = AndroidNotificationDetails(
-      mute ? 'Silent' : channelId,
+      mute ? 'Silent $channelId' : channelId,
       mute ? 'Silent' : channelName,
       channelDescription: isPreNotification ? 'Pre Adhan notifications for $prayer' : 'Adhan notifications for $prayer',
       importance: Importance.max,


### PR DESCRIPTION
This PR fixes https://github.com/mawaqit/mobile-app/issues/2123
### Issue description:
Notification making noise even in silent or vibration mode
It happens with the new release making notification follow the alarm level, but the problem is that most of the phone set the alarm volume on each alarm, so you can't disable the mawaqit notification
### Test cases: 
- Keep phone in silent mode or vibration and try trigger notification it will not play any sound.
- Use PR branch for testing in mobile side yaml.

```dart
  git:
      url: https://github.com/mawaqit/mobile-app-notifications
      ref: 2123-notification-making-noise-even-in-silent-or-vibration-mode
```