### PR TITLE
Fix app crash when mosque has no imsak prayer data

### DIFF
--- a/lib/prayer_services.dart
+++ b/lib/prayer_services.dart
@@ -134,10 +134,12 @@ class PrayerService {
     var index = prayerKeys.indexOf(key);
 
     if (index == 6) {
-      var calendar = mosque.imsakCalendar!;
+      if (mosque.imsakCalendar == null) return null;
+      var imsakCalendar = mosque.imsakCalendar!;
 
       var monthCalendar =
-          (calendar[now.month - 1] as Map<String, dynamic>).values.toList();
+          (imsakCalendar[now.month - 1] as Map<String, dynamic>).values.toList();
+      if (monthCalendar.isEmpty || now.day - 1 >= monthCalendar.length) return null;
       var prayerTime = monthCalendar[now.day - 1];
 
       var todayTime = DateTime(
@@ -153,8 +155,10 @@ class PrayerService {
     if (calendar != null) {
       var monthCalendar =
           (calendar[now.month - 1] as Map<String, dynamic>).values.toList();
+      if (monthCalendar.isEmpty || now.day - 1 >= monthCalendar.length) return null;
       var todayTimes = monthCalendar[now.day - 1];
 
+      if (todayTimes == null || index >= todayTimes.length) return null;
       var prayerTime = todayTimes[index];
 
       var todayTime = DateTime(


### PR DESCRIPTION
  This PR fixes https://github.com/mawaqit/mobile-app/issues/2701  
  Some mosques don't have imsak prayer configured, and in some cases
  the backend returns empty calendar data for certain months.

  The app was crashing when trying to schedule notifications for those
  mosques because it assumed the calendar data was always complete.

  This change makes the app handle missing or incomplete imsak data
  gracefully — it will simply skip scheduling the imsak notification
  for that mosque instead of crashing.