### PR TITLE
Skip adhan playback when notifications are disabled

### DIFF
--- a/lib/mobile_app_notifications.dart
+++ b/lib/mobile_app_notifications.dart
@@ -158,6 +158,16 @@ void ringAlarm(int id, Map<String, dynamic> data) async {
     if (isPreNotification) {
       await showPreNotification(id, prayer, notificationTitle, mosque);
     } else {
+      // Guard: with POST_NOTIFICATIONS denied, the foreground service still runs
+      // and MediaPlayer still plays, but the OS suppresses the notification — the
+      // adhan would sound with no visible source. Skip playback so audio stays
+      // coupled to a visible notification. Checked before the service starts (not
+      // inside it) to avoid the background startForegroundService → startForeground
+      // 5s contract. The `finally` below still reschedules tomorrow's alarms.
+      if (!await plugin.areNotificationsEnabled()) {
+        Log.w('Notifications disabled — skipping adhan playback for $prayer');
+        return;
+      }
       // Fix A: clear the matching pre-notification (if still in the tray) before
       // the adhan service posts its own notification. Pre-notif ID = adhan ID + 100000.
       try {

--- a/lib/src/notification_plugin.dart
+++ b/lib/src/notification_plugin.dart
@@ -1,9 +1,32 @@
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:mawaqit_core_logger/mawaqit_core_logger.dart';
 
 /// Shared `flutter_local_notifications` instance used by every code path that
 /// posts, schedules, cancels, or queries notifications in this package.
 final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
     FlutterLocalNotificationsPlugin();
+
+/// Whether the OS will actually display this app's notifications (app-level
+/// POST_NOTIFICATIONS on Android 13+). When notifications are denied, the adhan
+/// foreground service still runs and MediaPlayer still produces sound, but the
+/// notification is suppressed — so a real adhan would play with no visible
+/// source. `ringAlarm` uses this to skip playback in that state.
+///
+/// Fails open (returns `true`) on any error or non-Android platform so a
+/// transient failure can never silence the adhan.
+Future<bool> areNotificationsEnabled() async {
+  try {
+    final android = flutterLocalNotificationsPlugin
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>();
+    if (android == null) return true;
+    return await android.areNotificationsEnabled() ?? true;
+  } catch (e, s) {
+    Log.e('Failed reading notification permission — assuming enabled',
+        error: e, stackTrace: s);
+    return true;
+  }
+}
 
 Future<void> init() async {
   const initializationSettingsIOS = DarwinInitializationSettings(


### PR DESCRIPTION
## Problem
  When the user denies notification permission (POST_NOTIFICATIONS on Android 13+),
  the adhan still plays at the exact prayer time — but with **no visible
  notification**. The audio sounds "out of nowhere" with no way to see which prayer
  fired or to stop it.

  ## Root cause
  Adhan audio is played by `AdhanPlayerService` (a foreground service + MediaPlayer),
  decoupled from the notification for reliable deep-idle delivery. Because audio no
  longer depends on the notification being shown, a denied permission means the
  foreground service runs and plays sound while the OS suppresses its notification.

  ## Fix
  Gate real-adhan playback in `ringAlarm`: if notifications are disabled, skip
  playback so audio stays coupled to a visible notification.

  - The check runs **in Dart, before the service starts** — not inside the service —
    because guarding after a background `startForegroundService` would break the
    `startForeground()` 5-second contract and crash the app.
  - Uses `flutter_local_notifications`' `areNotificationsEnabled()` (already a
    dependency, already initialized) — no new native code or method channels.
  - **Fails open**: any error assumes notifications are enabled, so a transient
    failure can never silence the adhan.
  - Preview and pre-notification paths are untouched.

  ## Behavior
  | Notifications | Before | After |
  |---|---|---|
  | Granted | Adhan + notification | Adhan + notification (unchanged) |
  | Denied | Adhan audio only, no visible notification | Adhan skipped |